### PR TITLE
Fix README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ steps:
     name: my-artifact
     path: path/to/artifact
     
-- run: cat path/to/artifact/hello-world.txt
+- run: ls path/to/artifact
 ```
 
 # License

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ steps:
     name: my-artifact
     path: path/to/artifact
     
-- run: cat path/to/artifact
+- run: cat path/to/artifact/hello-world.txt
 ```
 
 # License


### PR DESCRIPTION
Resolves #17 
In the example of downloading an artifact, the run statement is:
```yaml
- run: cat path/to/artifact
```

This is invalid as `path/to/artifact` in this example is a directory, rather than a file, so `cat` will not work.

Changing this to `ls` the directory instead.