### PR TITLE
Download artifact relative to root folder

### DIFF
--- a/src/download-artifact.ts
+++ b/src/download-artifact.ts
@@ -1,17 +1,16 @@
 import * as core from '@actions/core'
 import * as artifact from '@actions/artifact'
 import {Inputs} from './constants'
-import * as path from 'path'
 
 async function run(): Promise<void> {
   try {
     const name = core.getInput(Inputs.Name, {required: false})
-    const targetPath = core.getInput(Inputs.Path, {required: false})
+    const path = core.getInput(Inputs.Path, {required: false})
 
     const artifactClient = artifact.create()
     if (!name) {
       // download all artifacts
-      const downloadResponse = await artifactClient.downloadAllArtifacts(targetPath)
+      const downloadResponse = await artifactClient.downloadAllArtifacts(path)
       core.info(`There were ${downloadResponse.length} artifacts downloaded`)
       for (const artifact of downloadResponse) {
         core.info(
@@ -23,9 +22,10 @@ async function run(): Promise<void> {
       const downloadOptions = {
         createArtifactFolder: true
       }
+      const targetPath = !path ? name : path; 
       const downloadResponse = await artifactClient.downloadArtifact(
         name,
-        path.join(targetPath, name),
+        targetPath,
         downloadOptions
       )
       core.info(

--- a/src/download-artifact.ts
+++ b/src/download-artifact.ts
@@ -21,7 +21,7 @@ async function run(): Promise<void> {
     } else {
       // download a single artifact
       const downloadOptions = {
-        createArtifactFolder: false
+        createArtifactFolder: true
       }
       const downloadResponse = await artifactClient.downloadArtifact(
         name,

--- a/src/download-artifact.ts
+++ b/src/download-artifact.ts
@@ -20,7 +20,7 @@ async function run(): Promise<void> {
     } else {
       // download a single artifact
       const downloadOptions = {
-        createArtifactFolder: false
+        createArtifactFolder: true
       }
       const downloadResponse = await artifactClient.downloadArtifact(
         name,

--- a/src/download-artifact.ts
+++ b/src/download-artifact.ts
@@ -1,16 +1,17 @@
 import * as core from '@actions/core'
 import * as artifact from '@actions/artifact'
 import {Inputs} from './constants'
+import * as path from 'path'
 
 async function run(): Promise<void> {
   try {
     const name = core.getInput(Inputs.Name, {required: false})
-    const path = core.getInput(Inputs.Path, {required: false})
+    const targetPath = core.getInput(Inputs.Path, {required: false})
 
     const artifactClient = artifact.create()
     if (!name) {
       // download all artifacts
-      const downloadResponse = await artifactClient.downloadAllArtifacts(path)
+      const downloadResponse = await artifactClient.downloadAllArtifacts(targetPath)
       core.info(`There were ${downloadResponse.length} artifacts downloaded`)
       for (const artifact of downloadResponse) {
         core.info(
@@ -20,11 +21,11 @@ async function run(): Promise<void> {
     } else {
       // download a single artifact
       const downloadOptions = {
-        createArtifactFolder: true
+        createArtifactFolder: false
       }
       const downloadResponse = await artifactClient.downloadArtifact(
         name,
-        path,
+        path.join(targetPath, name),
         downloadOptions
       )
       core.info(


### PR DESCRIPTION
The new version (V2) breaks existing workflows because it changed its default behavior of downloading artifact relative to the root folder.
This PR should fix this issue and it is compatible with version 1.0.0.

Closes #30