### PR TITLE
Add support for tilde expansion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,16 +68,24 @@ jobs:
         name: 'Artifact-A'
         path: some/new/path
 
+    # Test downloading an artifact using tilde expansion
+    - name: Download artifact A
+      uses: ./
+      with:
+        name: 'Artifact-A'
+        path: ~/some/path/with/a/tilde
+
     - name: Verify successful download
       run: |
-        $file = "some/new/path/file-A.txt"
-        if(!(Test-Path -path $file))
+        $file1 = "some/new/path/file-A.txt"
+        $file2 = "~/some/path/with/a/tilde/file-A.txt"
+        if(!(Test-Path -path $file1) -or !(Test-Path -path $file2))
         {
-            Write-Error "Expected file does not exist"
+            Write-Error "Expected files do not exist"
         }
-        if(!((Get-Content $file) -ceq "Lorem ipsum dolor sit amet"))
+        if(!((Get-Content $file1) -ceq "Lorem ipsum dolor sit amet") -or !((Get-Content $file2) -ceq "Lorem ipsum dolor sit amet"))
         {
-            Write-Error "File contents of downloaded artifact are incorrect"
+            Write-Error "File contents of downloaded artifacts are incorrect"
         }
       shell: pwsh
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ steps:
   working-directory: path/to/artifact
 ```
 
+Basic tilde expansion is supported for the `path` input
+
+```yaml
+  - uses: actions/download-artifact@v2
+    with:
+      name: my-artifact
+      path: ~/download/path
+```
+
 ## Compatibility between `v1` and `v2`
 
 When using `download-artifact@v1`, a directory denoted by the name of the artifact would be created if the `path` input was not provided. All of the contents would be downloaded to this directory.

--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ steps:
   working-directory: path/to/artifact
 ```
 
-Basic tilde expansion is supported for the `path` input
-
+Basic tilde expansion is supported for the `path` input:
 ```yaml
   - uses: actions/download-artifact@v2
     with:

--- a/dist/index.js
+++ b/dist/index.js
@@ -6643,7 +6643,8 @@ function run() {
             const name = core.getInput(constants_1.Inputs.Name, { required: false });
             const path = core.getInput(constants_1.Inputs.Path, { required: false });
             let resolvedPath;
-            if (path === '~' || path.startsWith(`~${path_1.sep}`)) {
+            // resolve tilde expansions, path.replace only replaces the first occurrence of a pattern
+            if (path.startsWith(`~`)) {
                 resolvedPath = path_1.resolve(path.replace('~', os.homedir()));
             }
             else {

--- a/dist/index.js
+++ b/dist/index.js
@@ -6644,6 +6644,7 @@ function run() {
             const path = core.getInput(constants_1.Inputs.Path, { required: false });
             // resolve tilde expansion
             const resolvedPath = path_1.resolve(path.replace('~', os.homedir));
+            core.debug(`Resolved path is ${resolvedPath}`);
             const artifactClient = artifact.create();
             if (!name) {
                 // download all artifacts

--- a/dist/index.js
+++ b/dist/index.js
@@ -6634,6 +6634,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
 const artifact = __importStar(__webpack_require__(214));
+const os = __importStar(__webpack_require__(87));
 const path_1 = __webpack_require__(622);
 const constants_1 = __webpack_require__(694);
 function run() {
@@ -6641,12 +6642,14 @@ function run() {
         try {
             const name = core.getInput(constants_1.Inputs.Name, { required: false });
             const path = core.getInput(constants_1.Inputs.Path, { required: false });
+            // resolve tilde expansion
+            const resolvedPath = path_1.resolve(path.replace('~', os.homedir));
             const artifactClient = artifact.create();
             if (!name) {
                 // download all artifacts
                 core.info('No artifact name specified, downloading all artifacts');
                 core.info('Creating an extra directory for each artifact that is being downloaded');
-                const downloadResponse = yield artifactClient.downloadAllArtifacts(path);
+                const downloadResponse = yield artifactClient.downloadAllArtifacts(resolvedPath);
                 core.info(`There were ${downloadResponse.length} artifacts downloaded`);
                 for (const artifact of downloadResponse) {
                     core.info(`Artifact ${artifact.artifactName} was downloaded to ${artifact.downloadPath}`);
@@ -6658,12 +6661,12 @@ function run() {
                 const downloadOptions = {
                     createArtifactFolder: false
                 };
-                const downloadResponse = yield artifactClient.downloadArtifact(name, path, downloadOptions);
+                const downloadResponse = yield artifactClient.downloadArtifact(name, resolvedPath, downloadOptions);
                 core.info(`Artifact ${downloadResponse.artifactName} was downloaded to ${downloadResponse.downloadPath}`);
             }
             // output the directory that the artifact(s) was/were downloaded to
             // if no path is provided, an empty string resolves to the current working directory
-            core.setOutput(constants_1.Outputs.DownloadPath, path_1.resolve(path));
+            core.setOutput(constants_1.Outputs.DownloadPath, resolvedPath);
             core.info('Artifact download has finished successfully');
         }
         catch (err) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -6642,8 +6642,13 @@ function run() {
         try {
             const name = core.getInput(constants_1.Inputs.Name, { required: false });
             const path = core.getInput(constants_1.Inputs.Path, { required: false });
-            // resolve tilde expansion
-            const resolvedPath = path_1.resolve(path.replace('~', os.homedir));
+            let resolvedPath;
+            if (path === '~' || path.startsWith(`~${path_1.sep}`)) {
+                resolvedPath = path_1.resolve(path.replace('~', os.homedir()));
+            }
+            else {
+                resolvedPath = path_1.resolve(path);
+            }
             core.debug(`Resolved path is ${resolvedPath}`);
             const artifactClient = artifact.create();
             if (!name) {

--- a/src/download-artifact.ts
+++ b/src/download-artifact.ts
@@ -11,6 +11,7 @@ async function run(): Promise<void> {
 
     // resolve tilde expansion
     const resolvedPath = resolve(path.replace('~', os.homedir))
+    core.debug(`Resolved path is ${resolvedPath}`)
 
     const artifactClient = artifact.create()
     if (!name) {

--- a/src/download-artifact.ts
+++ b/src/download-artifact.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core'
 import * as artifact from '@actions/artifact'
 import * as os from 'os'
-import {resolve} from 'path'
+import {resolve, sep} from 'path'
 import {Inputs, Outputs} from './constants'
 
 async function run(): Promise<void> {
@@ -9,8 +9,12 @@ async function run(): Promise<void> {
     const name = core.getInput(Inputs.Name, {required: false})
     const path = core.getInput(Inputs.Path, {required: false})
 
-    // resolve tilde expansion
-    const resolvedPath = resolve(path.replace('~', os.homedir))
+    let resolvedPath
+    if (path === '~' || path.startsWith(`~${sep}`)) {
+      resolvedPath = resolve(path.replace('~', os.homedir()))
+    } else {
+      resolvedPath = resolve(path)
+    }
     core.debug(`Resolved path is ${resolvedPath}`)
 
     const artifactClient = artifact.create()

--- a/src/download-artifact.ts
+++ b/src/download-artifact.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core'
 import * as artifact from '@actions/artifact'
 import * as os from 'os'
-import {resolve, sep} from 'path'
+import {resolve} from 'path'
 import {Inputs, Outputs} from './constants'
 
 async function run(): Promise<void> {
@@ -10,7 +10,8 @@ async function run(): Promise<void> {
     const path = core.getInput(Inputs.Path, {required: false})
 
     let resolvedPath
-    if (path === '~' || path.startsWith(`~${sep}`)) {
+    // resolve tilde expansions, path.replace only replaces the first occurrence of a pattern
+    if (path.startsWith(`~`)) {
       resolvedPath = resolve(path.replace('~', os.homedir()))
     } else {
       resolvedPath = resolve(path)


### PR DESCRIPTION
## Overview

Resolves: https://github.com/actions/download-artifact/issues/37

Upload-artifact supports basic tilde expansion using the [actions/glob](https://github.com/actions/toolkit/tree/main/packages/glob#tilde-expansion) npm package. It is also possible use tilde expansion in shell scripts on all hosted virtual environments so it logically makes sense for us to support it for `download-artifact`.

I didn't want to take a dependency on some NPM package so I copied what most packages & users do which is to replace `~` with `os.homedir`: https://stackoverflow.com/questions/21077670/expanding-resolving-in-node-js

The `README` was updated to document the new feature:
🖼 [Rendered](https://github.com/actions/download-artifact/blob/konradpabjan/tilde/README.md) 🖌

## Testing

- Added extra CI test
- Local testing
   - Windows with tilde: https://github.com/konradpabjan/artifact-test/runs/922981408?check_suite_focus=true
   - Windows with no Path: https://github.com/konradpabjan/artifact-test/runs/922997220?check_suite_focus=true
   - Linux with tilde: https://github.com/konradpabjan/artifact-test/runs/923008381?check_suite_focus=true
   - Linux with no Path: https://github.com/konradpabjan/artifact-test/runs/923003162?check_suite_focus=true

Since `~` is a bash specific feature, I double checked what `~` resolves to on Windows and is `C:\Users\runneradmin\` which is what `upload-artifact` and our shell scripts resolve to if using tilde expansion.