### PR TITLE
Clarified the `v1` and `v2` differences

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ When using `download-artifact@v1`, a directory denoted by the name of the artifa
           ... contents of my-artifact
 ```
 
-With `v2`, there is no longer an extra directory that is created if the `path` input is not provided. All the contents are downloaded to the current working directory.
+With `v2`, when an artifact is specified by the `name` input, there is no longer an extra directory that is created if the `path` input is not provided. All the contents are downloaded to the current working directory.
 ```
    current/working/directory/
       ... contents of my-artifact


### PR DESCRIPTION
The original text implies by supplying no inputs all files are placed in the root directory without added directories by focusing only on the `path` input. In practice, supplying no inputs results in the backwards compatible `v1` behavior of creating an extra parameter. This may be obvious in some scenarios and stated somewhat later in the document, but is less obvious when the "name" matches a filename for a single file artifact.