### PR TITLE
Ingest v0.5.2 of @actions/artifact

### DIFF
--- a/.licenses/npm/@actions/artifact.dep.yml
+++ b/.licenses/npm/@actions/artifact.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: "@actions/artifact"
-version: 0.5.1
+version: 0.5.2
 type: npm
 summary: Actions artifact lib
 homepage: https://github.com/actions/toolkit/tree/main/packages/artifact

--- a/dist/index.js
+++ b/dist/index.js
@@ -7465,8 +7465,9 @@ function isRetryableStatusCode(statusCode) {
     }
     const retryableStatusCodes = [
         http_client_1.HttpCodes.BadGateway,
-        http_client_1.HttpCodes.ServiceUnavailable,
         http_client_1.HttpCodes.GatewayTimeout,
+        http_client_1.HttpCodes.InternalServerError,
+        http_client_1.HttpCodes.ServiceUnavailable,
         http_client_1.HttpCodes.TooManyRequests,
         413 // Payload Too Large
     ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@actions/artifact": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-0.5.1.tgz",
-      "integrity": "sha512-wKXEa4fhvgsw3kPu74F3J6eAi92rqv7BvpjEAmiqmDFeuDj6cyqWDWXx6axWfiBmmln1/LVf1DLWikbciKkoVQ==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-0.5.2.tgz",
+      "integrity": "sha512-q/r8WSqyxBJ0ffLCRrtjCBTGnAYqP+ID4yG7f7YSlhrQ4thNg/d+Tq9f1YkLPKX46ZR97OWtGDY+oU/nxcqvLw==",
       "requires": {
         "@actions/core": "^1.2.6",
         "@actions/http-client": "^1.0.11",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/actions/download-artifact#readme",
   "dependencies": {
-    "@actions/artifact": "^0.5.1",
+    "@actions/artifact": "^0.5.2",
     "@actions/core": "^1.2.6"
   },
   "devDependencies": {


### PR DESCRIPTION
v0.5.2 now considers HTTP 500 a retriable status code.  See https://github.com/actions/toolkit/pull/845.

See also https://github.com/actions/upload-artifact/pull/224.