### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,13 +2,12 @@ name: Test
 on:
   push:
     paths-ignore:
-      - '**.md'
+      - "**.md"
   pull_request:
     paths-ignore:
-      - '**.md'
+      - "**.md"
 
 jobs:
-
   build:
     name: Build
 
@@ -20,93 +19,92 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Set Node.js 12.x
-      uses: actions/setup-node@v1
-      with:
-        node-version: 12.x
+      - name: Set Node.js 12.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.x
+          cache: npm
 
-    - name: npm install
-      run: npm install
+      - name: npm install
+        run: npm install
 
-    - name: Compile
-      run: npm run build
+      - name: Compile
+        run: npm run build
 
-    - name: Lint
-      run: npm run lint
+      - name: Lint
+        run: npm run lint
 
-    - name: Format
-      run: npm run format-check 
+      - name: Format
+        run: npm run format-check
 
-    # Test end-to-end by uploading two artifacts and then downloading them
-    # Once upload-artifact v2 is out of preview, switch over
-    - name: Create artifacts
-      run: |
-        mkdir -p path/to/artifact-A
-        mkdir -p path/to/artifact-B
-        echo "Lorem ipsum dolor sit amet" > path/to/artifact-A/file-A.txt
-        echo "Hello world from file B" > path/to/artifact-B/file-B.txt
-    
-    - name: Upload artifact A
-      uses: actions/upload-artifact@v1
-      with:
-        name: 'Artifact-A'
-        path: path/to/artifact-A
+      # Test end-to-end by uploading two artifacts and then downloading them
+      # Once upload-artifact v2 is out of preview, switch over
+      - name: Create artifacts
+        run: |
+          mkdir -p path/to/artifact-A
+          mkdir -p path/to/artifact-B
+          echo "Lorem ipsum dolor sit amet" > path/to/artifact-A/file-A.txt
+          echo "Hello world from file B" > path/to/artifact-B/file-B.txt
 
-    - name: Upload artifact B
-      uses: actions/upload-artifact@v1
-      with:
-        name: 'Artifact-B'
-        path: path/to/artifact-B
+      - name: Upload artifact A
+        uses: actions/upload-artifact@v1
+        with:
+          name: "Artifact-A"
+          path: path/to/artifact-A
 
-    # Test downloading a single artifact
-    - name: Download artifact A
-      uses: ./
-      with:
-        name: 'Artifact-A'
-        path: some/new/path
+      - name: Upload artifact B
+        uses: actions/upload-artifact@v1
+        with:
+          name: "Artifact-B"
+          path: path/to/artifact-B
 
-    # Test downloading an artifact using tilde expansion
-    - name: Download artifact A
-      uses: ./
-      with:
-        name: 'Artifact-A'
-        path: ~/some/path/with/a/tilde
+      # Test downloading a single artifact
+      - name: Download artifact A
+        uses: ./
+        with:
+          name: "Artifact-A"
+          path: some/new/path
 
-    - name: Verify successful download
-      run: |
-        $file1 = "some/new/path/file-A.txt"
-        $file2 = "~/some/path/with/a/tilde/file-A.txt"
-        if(!(Test-Path -path $file1) -or !(Test-Path -path $file2))
-        {
-            Write-Error "Expected files do not exist"
-        }
-        if(!((Get-Content $file1) -ceq "Lorem ipsum dolor sit amet") -or !((Get-Content $file2) -ceq "Lorem ipsum dolor sit amet"))
-        {
-            Write-Error "File contents of downloaded artifacts are incorrect"
-        }
-      shell: pwsh
+      # Test downloading an artifact using tilde expansion
+      - name: Download artifact A
+        uses: ./
+        with:
+          name: "Artifact-A"
+          path: ~/some/path/with/a/tilde
 
-    # Test downloading both artifacts at once
-    - name: Download all Artifacts
-      uses: ./
-      with:
-        path: some/other/path
+      - name: Verify successful download
+        run: |
+          $file1 = "some/new/path/file-A.txt"
+          $file2 = "~/some/path/with/a/tilde/file-A.txt"
+          if(!(Test-Path -path $file1) -or !(Test-Path -path $file2))
+          {
+              Write-Error "Expected files do not exist"
+          }
+          if(!((Get-Content $file1) -ceq "Lorem ipsum dolor sit amet") -or !((Get-Content $file2) -ceq "Lorem ipsum dolor sit amet"))
+          {
+              Write-Error "File contents of downloaded artifacts are incorrect"
+          }
+        shell: pwsh
 
-    - name: Verify successful download
-      run: |
-        $fileA = "some/other/path/Artifact-A/file-A.txt"
-        $fileB = "some/other/path/Artifact-B/file-B.txt"
-        if(!(Test-Path -path $fileA) -or !(Test-Path -path $fileB))
-        {
-            Write-Error "Expected files do not exist"
-        }
-        if(!((Get-Content $fileA) -ceq "Lorem ipsum dolor sit amet") -or !((Get-Content $fileB) -ceq "Hello world from file B"))
-        {
-            Write-Error "File contents of downloaded artifacts are incorrect"
-        }
-      shell: pwsh
+      # Test downloading both artifacts at once
+      - name: Download all Artifacts
+        uses: ./
+        with:
+          path: some/other/path
 
-      
+      - name: Verify successful download
+        run: |
+          $fileA = "some/other/path/Artifact-A/file-A.txt"
+          $fileB = "some/other/path/Artifact-B/file-B.txt"
+          if(!(Test-Path -path $fileA) -or !(Test-Path -path $fileB))
+          {
+              Write-Error "Expected files do not exist"
+          }
+          if(!((Get-Content $fileA) -ceq "Lorem ipsum dolor sit amet") -or !((Get-Content $fileB) -ceq "Hello world from file B"))
+          {
+              Write-Error "File contents of downloaded artifacts are incorrect"
+          }
+        shell: pwsh


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
