### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,63 @@
+name: "🐛 Bug report"
+description: Let us know about a bug!
+labels: ['bug']
+title: '[bug]'
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: |
+        Please provide a clear and concise description of what the bug is. If applicable, add screenshots to help explain your problem.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: How can we reproduce it?
+      description: |
+        Please be minimal and precise as possible. If your repo/run is public, please include a URL so it is easier for us to investigate.
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Anything else we need to know?
+
+  - type: input
+    id: version
+    attributes:
+      label: What version of the action are you using?
+      placeholder: vX.Y.Z
+      description: |
+        Please check the documentation first since different major versions can have different behaviors.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: What are your runner environments?
+      multiple: true
+      options:
+        - self-hosted
+        - linux
+        - window
+        - macos
+    validations:
+      required: true
+
+  - type: input
+    id: ghes
+    attributes:
+      label: Are you on GitHub Enterprise Server? If so, what version?
+      placeholder: vX.Y

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🙋 Ask a question
+    url: https://github.community/c/code-to-cloud/52
+    about: Please ask and answer questions on GitHub Support Community.
+  - name: 🔒 Report security vulnerability
+    url: https://bounty.github.com/
+    about: Please report security vulnerabilities to GitHub Security Bug Bounty.

--- a/.github/ISSUE_TEMPLATE/documentation-issues.yml
+++ b/.github/ISSUE_TEMPLATE/documentation-issues.yml
@@ -1,0 +1,28 @@
+name: "📚 Documentation issues"
+description: Make a suggestion to improve the documentation!
+labels: ['documentation']
+title: '[docs]'
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ❗ This is only for documentation updates for files in this repo, ie: `README.md`.
+        
+        If you want to suggest changes for the [GitHub Docs](https://docs.github.com/), please [open an issue there](https://github.com/github/docs/issues/new/choose).
+  - type: textarea
+    id: affected
+    attributes:
+      label: What files would you like to change?
+      description: |
+        Please provide permalinks to the specified files and line numbers.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggested
+    attributes:
+      label: What are your suggested changes?
+      description: |
+        Give as much detail as you can to help us understand the changes you want to see.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,20 @@
+name: "🎁 Feature request"
+description: Suggest a new feature/enhancement!
+labels: ['enhancement']
+title: '[feat req]'
+body:
+  - type: textarea
+    id: feature
+    attributes:
+      label: What would you like to be added?
+      description: |
+        Please check existing issues to avoid making duplicates. Any duplicate issue will be closed immediately.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reasoning
+    attributes:
+      label: Why is this needed?
+    validations:
+      required: true


### PR DESCRIPTION
Adds the following issues templates:

- Bug report: template form w/ auto label
- Documentation issues: template form w/ auto label
- Feature request: template form w/ auto label
- Ask a question: link to github.community
- Security vulnerability: link to bounty.github.com

This'll help make our triage flow a bit faster.