### PR TITLE
Update default runtime to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,5 +9,5 @@ inputs:
     description: 'Destination path'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Node 12 has an end of life on April 30, 2022.

This PR updates the default runtime to [node16](https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/), rather then node12. 

This is supported on all Actions Runners v2.285.0 or later.