### PR TITLE
Use cache in check-dist.yml

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -25,9 +25,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set Node.js 12.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 12.x
+          cache: npm
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

Use cache in `check-dist.yml`
See [actions/cache#1004](https://github.com/actions/cache/pull/1004)

**AS-IS**

```yaml
- name: Set Node.js 12.x
  uses: actions/setup-node@v1
  with:
    node-version: 12.x
```

**TO-BE**

```yaml
- name: Set Node.js 12.x
  uses: actions/setup-node@v3
  with:
    node-version: 12.x
    cache: npm
```

> It’s literally a one line change to pass the `cache: npm` input parameter.