### PR TITLE
Add download-path output to action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   path:
     description: 'Destination path'
     required: false
+outputs:
+  download-path:
+    description: 'Path of artifact download'
 runs:
   using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Closes #153
Reference: https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs-for-docker-container-and-javascript-actions

Prevents false positives from tooling, such as `actionlint`, that depends on the metadata for static analysis.