### PR TITLE
Update release-new-action-version.yml

### DIFF
--- a/.github/workflows/release-new-action-version.yml
+++ b/.github/workflows/release-new-action-version.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Update the ${{ env.TAG_NAME }} tag
-      uses: actions/publish-action@v0.1.0
+      uses: actions/publish-action@v0.2.1
       with:
         source-tag: ${{ env.TAG_NAME }}
         slack-webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
Similar to https://github.com/actions/upload-artifact/pull/363

https://github.com/actions/publish-action/releases/tag/v0.2.1

We use this workflow for automated publishing and we should use the latest version of the action