### PR TITLE
feat: bump to use node20 runtime, actions/checkout to v4

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node 16
         uses: actions/setup-node@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/licensed.yml
+++ b/.github/workflows/licensed.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Check licenses
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: npm ci
       - name: Install licensed
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # using node 16 since that is what the latest version of the runner ships with
     - name: Setup Node 16

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See [action.yml](action.yml)
 Basic (download to the current working directory):
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 
 - uses: actions/download-artifact@v3
   with:
@@ -34,7 +34,7 @@ steps:
 Download to a specific directory:
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 
 - uses: actions/download-artifact@v3
   with:
@@ -93,7 +93,7 @@ Example, if there are two artifacts `Artifact-A` and `Artifact-B`, and the direc
 Download all artifacts to a specific directory
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 
 - uses: actions/download-artifact@v3
   with:
@@ -107,7 +107,7 @@ steps:
 Download all artifacts to the current working directory
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 
 - uses: actions/download-artifact@v3
 
@@ -121,7 +121,7 @@ The `download-path` step output contains information regarding where the artifac
 
 ```yaml
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 
 - uses: actions/download-artifact@v3
   id: download

--- a/action.yml
+++ b/action.yml
@@ -12,5 +12,5 @@ outputs:
   download-path:
     description: 'Path of artifact download'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
**Description:**

Node 16 reaches the [end of life soon on 11 Sep 2023](https://nodejs.org/en/blog/announcements/nodejs16-eol). This PR updates the default runtime to `node20` (Node 20). I have also bumped the actions/checkout version to v4 for the same.

**Related issue:**

https://github.com/actions/runner/pull/2732

Closes #230

-----------------
A major version bump might be needed after the PRs merge.