### PR TITLE
[v4 beta] Fixes to download directory structure

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,5 +25,5 @@ outputs:
   download-path:
     description: 'Path of artifact download'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/src/download-artifact.ts
+++ b/src/download-artifact.ts
@@ -40,10 +40,11 @@ async function run(): Promise<void> {
     )
   }
 
+  const isSingleArtifactDownload = !!inputs.name
   const artifactClient = artifact.create()
   let artifacts: artifact.Artifact[] = []
 
-  if (inputs.name) {
+  if (isSingleArtifactDownload) {
     const {artifact: targetArtifact} = await artifactClient.getArtifact(
       inputs.name,
       inputs.runID,
@@ -81,7 +82,7 @@ async function run(): Promise<void> {
 
   const downloadPromises = artifacts.map(artifact =>
     artifactClient.downloadArtifact(artifact.id, owner, repo, inputs.token, {
-      path: path.join(resolvedPath, artifact.name)
+      path: isSingleArtifactDownload? resolvedPath : path.join(resolvedPath, inputs.name)
     })
   )
 


### PR DESCRIPTION
Part of https://github.com/github/actions-results-team/issues/1987

We need to ensure that download compatibility is identical between v3 and v4. This fixes v4 to ensure that there is no extra directory with the artifact name when download a single artifact. If downloading multiple artifacts at once then there is an extra directory.

See this run that compares single & multiple uploads between v3 and v4 https://github.com/bbq-beets/testing-artifacts-v4/actions/runs/6662193261

Multiple downloads:
![image](https://github.com/actions/download-artifact/assets/16109154/ed16419c-7931-4fac-aa76-14e41d6b8b56)

Single download:
![image](https://github.com/actions/download-artifact/assets/16109154/b531de2c-c8f1-4fb1-9fc4-187bdb1d8541)

