### PR TITLE
Add `if-not-found` parameter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,3 +106,96 @@ jobs:
             Write-Error "File contents of downloaded artifacts are incorrect"
         }
       shell: pwsh
+
+  if-not-found-with-name:
+    name: Test `if-not-found` param wih name specified
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Verify not existing artifact with default value
+      id: default
+      continue-on-error: true
+      uses: ./
+      with:
+        name: not-existing-name
+
+    - name: Check default
+      run: ${{ steps.default.outcome == 'failure' }} 
+    
+    - name: Verify not existing artifact `error`
+      id: error
+      continue-on-error: true
+      uses: ./
+      with:
+        name: not-existing-name
+        if-not-found: error
+
+    - name: Check `error`
+      run: ${{ steps.error.outcome == 'failure' }} 
+  
+    - name: Verify not existing artifact `warning`
+      id: warning
+      uses: ./
+      with:
+        name: not-existing-name
+        if-not-found: warn
+
+    - name: Check `warning`
+      run: ${{ steps.warning.outcome == 'success' }} 
+
+    - name: Verify not existing artifact `ignore`
+      id: ignore
+      uses: ./
+      with:
+        name: not-existing-name
+        if-not-found: ignore
+
+    - name: Check `ignore`
+      run: ${{ steps.ignore.outcome == 'success' }} 
+  
+  if-not-found-without-name:
+    name: Test `if-not-found` param wih name specified
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Verify not existing artifact with default value
+      id: default
+      continue-on-error: true
+      uses: ./
+
+    - name: Check default
+      run: ${{ steps.default.outcome == 'failure' }} 
+    
+    - name: Verify not existing artifact `error`
+      id: error
+      continue-on-error: true
+      uses: ./
+      with:
+        if-not-found: error
+
+    - name: Check `error`
+      run: ${{ steps.error.outcome == 'failure' }} 
+  
+    - name: Verify not existing artifact `warning`
+      id: warning
+      uses: ./
+      with:
+        if-not-found: warn
+
+    - name: Check `warning`
+      run: ${{ steps.warning.outcome == 'success' }} 
+
+    - name: Verify not existing artifact `ignore`
+      id: ignore
+      uses: ./
+      with:
+        if-not-found: ignore
+
+    - name: Check `ignore`
+      run: ${{ steps.ignore.outcome == 'success' }} 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ For more information, see the [`@actions/artifact`](https://github.com/actions/t
 
     # The id of the workflow run where the desired download artifact was uploaded from.
     # If github-token is specified, this is the run that artifacts will be downloaded from.
-    # Optional. Default is ${{ github.repository }}
+    # Optional. Default is ${{ github.run_id }}
     run-id:
 ```
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ steps:
   run: ls -R your/destination/dir
 ```
 
+## Name not found
+
+By default, if the name you provided doesn't exists or there are no artifacts, the action will raise an error.
+It is possible to change this behavior using the `if-not-found` optional parameter:
+
+- `error`: output a warning but do not fail the action (default)
+- `warning`: fail the action with an error message
+- `ignore`: do not output any warnings or errors, the action does not fail
+
 
 ### Download All Artifacts
 

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
       If github-token is specified, this is the run that artifacts will be downloaded from.'
     required: false
     default: ${{ github.run_id }}
+  if-not-found:
+    description: 'How to behave if no artifact(s) is(are) found'
+    required: false
+    default: error
 outputs:
   download-path:
     description: 'Path of artifact download'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,9 +3,27 @@ export enum Inputs {
   Path = 'path',
   GitHubToken = 'github-token',
   Repository = 'repository',
-  RunID = 'run-id'
+  RunID = 'run-id',
+  IfNotFound = 'if-not-found'
 }
 
 export enum Outputs {
   DownloadPath = 'download-path'
+}
+
+export enum NotFoundOptions {
+  /**
+   * Default. Output a warning but do not fail the action
+   */
+  warn = 'warn',
+
+  /**
+   * Fail the action with an error message
+   */
+  error = 'error',
+
+  /**
+   * Do not output any warnings or errors, the action does not fail
+   */
+  ignore = 'ignore'
 }


### PR DESCRIPTION
Hi, I'm Dario, a Tech PO at [hiop](https://hiop.io/)

I added an optional parameter to the action, `if-no-name-found`, allowing users to change the behavior when a specific artifact name is not found.
To do this I followed what is implemented in the counterpart of this action, namely [upload-artifact](https://github.com/actions/upload-artifact)

I believe this parameter gives more control to the user, for example when using reusable workflows that may or may not have that specific artifact (this is my case).

I added some tests and added a subsection to the `README`. Please let me know if there is anything more you need or to discuss about this feature