### PR TITLE
Allow downloading all artifacts of which the names start with a given prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,14 @@ For more information, see the [`@actions/artifact`](https://github.com/actions/t
 - uses: actions/download-artifact@v4
   with:
     # Name of the artifact to download.
-    # Optional. If unspecified, all artifacts for the run are downloaded.
+    # Optional. If unspecified, all artifacts for the run are downloaded, unless restricted by `name-prefix`.
     name:
+
+    # Name prefix of artifacts to download.
+    # If specified, download all artifacts of which the name starts with the given prefix.
+    # This is useful for aggregating artifacts produced by matrix jobs, for example.
+    # Optional; only meaningful if `name` is unspecified. 
+    name-prefix:
 
     # Destination path. Supports basic tilde expansion.
     # Optional. Defaults is $GITHUB_WORKSPACE

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,11 @@ description: 'Download a build artifact that was previously uploaded in the work
 author: 'GitHub'
 inputs:
   name:
-    description: 'Name of the artifact to download. If unspecified, all artifacts for the run are downloaded'
+    description: 'Name of the artifact to download. If unspecified, all artifacts for the run are downloaded, 
+      unless filtered out by name-prefix.'
+    required: false
+  name-prefix:
+    description: 'Download all artifacts starting with this prefix.'
     required: false
   path:
     description: 'Destination path. Supports basic tilde expansion. Defaults to $GITHUB_WORKSPACE'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,6 @@
 export enum Inputs {
   Name = 'name',
+  NamePrefix = 'name-prefix',
   Path = 'path',
   GitHubToken = 'github-token',
   Repository = 'repository',


### PR DESCRIPTION
This PR adds the `name-prefix` input parameter to allow downloading multiple artifacts of which the names share a common prefix.

This is useful for aggregating artifacts produced by matrix runs (e.g. reports from matrixed test jobs).

Provides a smoother migration path for the use cases in #248.

-------------------

Note: I would've added unit tests, but apparently this project doesn't have any (or am I not looking in the right place)? Comments welcome, I don't do typescript very often.