### PR TITLE
Using node16 to support centOS 7 runners

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,5 +27,5 @@ outputs:
   download-path:
     description: 'Path of artifact download'
 runs:
-  using: 'node20'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
To support CentOS 7 that is not compatible with node20, we need to keep a fork of v4 release that would work with centOS 7 self-hosted runners 

Ref issue: https://github.com/actions/runner/issues/2906