### PR TITLE
Clarify log messages when using `pattern` or `merge-multiple` params

### DIFF
--- a/src/download-artifact.ts
+++ b/src/download-artifact.ts
@@ -75,10 +75,6 @@ async function run(): Promise<void> {
 
     artifacts = [targetArtifact]
   } else {
-    core.info(
-      `No input name specified, downloading all artifacts. Extra directory with the artifact name will be created for each download`
-    )
-
     const listArtifactResponse = await artifactClient.listArtifacts({
       latest: true,
       ...options
@@ -94,6 +90,15 @@ async function run(): Promise<void> {
       core.debug(
         `Filtered from ${listArtifactResponse.artifacts.length} to ${artifacts.length} artifacts`
       )
+    } else {
+      core.info(
+        'No input name or pattern filtered specified, downloading all artifacts'
+      )
+      if (!inputs.mergeMultiple) {
+        core.info(
+          'An extra directory with the artifact name will be created for each download'
+        )
+      }
     }
   }
 


### PR DESCRIPTION
Addresses: 
- https://github.com/actions/download-artifact/issues/262

When using pattern filters or merge multiple, it'll still log out the following:

```
No input name specified, downloading all artifacts. Extra directory with the artifact name will be created for each download
```

This adds some conditionals to the logging to be more correct.