### PR TITLE
updating artifact dependency to version 2.1.1

### DIFF
--- a/.licenses/npm/@actions/artifact.dep.yml
+++ b/.licenses/npm/@actions/artifact.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: "@actions/artifact"
-version: 2.0.1
+version: 2.1.1
 type: npm
 summary: 
 homepage: 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.0.1",
       "license": "MIT",
       "dependencies": {
-        "@actions/artifact": "^2.0.1",
+        "@actions/artifact": "^2.1.1",
         "@actions/core": "^1.10.0",
         "@actions/github": "^5.1.1",
         "minimatch": "^9.0.3"
@@ -36,9 +36,9 @@
       }
     },
     "node_modules/@actions/artifact": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-2.0.1.tgz",
-      "integrity": "sha512-MGgWRU4n4yoGQ5NbfwKWl3whSuFG/ll2FZ1au+jAiOIykKk+dnTFMuiklomsD6yx56ZnkQTVa/0Se5N0T0f6Nw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-2.1.1.tgz",
+      "integrity": "sha512-xVVwWhrRb4YLiTeYkNxctv9IhwIKUsLwIhqD9CKknXtQaqIksq5HttFN8wXQvMrpjQO4zGJf5xLUs6mKyfN4yQ==",
       "dependencies": {
         "@actions/core": "^1.10.0",
         "@actions/github": "^5.1.1",
@@ -5862,9 +5862,9 @@
       "dev": true
     },
     "@actions/artifact": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-2.0.1.tgz",
-      "integrity": "sha512-MGgWRU4n4yoGQ5NbfwKWl3whSuFG/ll2FZ1au+jAiOIykKk+dnTFMuiklomsD6yx56ZnkQTVa/0Se5N0T0f6Nw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-2.1.1.tgz",
+      "integrity": "sha512-xVVwWhrRb4YLiTeYkNxctv9IhwIKUsLwIhqD9CKknXtQaqIksq5HttFN8wXQvMrpjQO4zGJf5xLUs6mKyfN4yQ==",
       "requires": {
         "@actions/core": "^1.10.0",
         "@actions/github": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/actions/download-artifact#readme",
   "dependencies": {
-    "@actions/artifact": "^2.0.1",
+    "@actions/artifact": "^2.1.1",
     "@actions/core": "^1.10.0",
     "@actions/github": "^5.1.1",
     "minimatch": "^9.0.3"


### PR DESCRIPTION
We made [changes](https://github.com/actions/toolkit/pull/1648) to the `@actions/artifact` dependency so we want to update to the latest package version 2.1.1 