### PR TITLE
Add allow-not-found input argument

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,3 +128,15 @@ jobs:
             Write-Error "File contents of downloaded artifacts are incorrect"
         }
       shell: pwsh
+
+    - name: Download non-existent Artifact
+      id: not-existent-artifact
+      uses: ./
+      with:
+        name: Artifact-C-${{ matrix.runs-on }}
+        allow-not-found: true
+
+    - name: Verify empty download-path output
+      if: ${{ steps.not-existent-artifact.outputs.download-path != '' }}
+      run: |
+        Write-Error "Expected download-path output is not empty"

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
       If false, the downloaded artifacts will be extracted into individual named directories within the specified path.'
     required: false
     default: 'false'
+  allow-not-found:
+    description: 'If an artifact was not found, do not cause the action to fail.'
+    required: false
+    default: 'false'
   github-token:
     description: 'The GitHub token used to authenticate with the GitHub API.
       This is required when downloading artifacts from a different repository or from a different workflow run.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,7 +5,8 @@ export enum Inputs {
   Repository = 'repository',
   RunID = 'run-id',
   Pattern = 'pattern',
-  MergeMultiple = 'merge-multiple'
+  MergeMultiple = 'merge-multiple',
+  AllowNotFound = 'allow-not-found'
 }
 
 export enum Outputs {


### PR DESCRIPTION
Closes #42

This PR adds the `allow-not-found` input argument to `download-artifact` that, when set to `true`, will not fail the action when an artifact with the specified `name` input argument is not found.

If the artifact is not found, the output of `download-path` of the action will contain an empty string instead of the would-be download path. This can be checked in the subsequent step via `${{ steps.<id>.outputs.download-path != '' }}` as can be seen in the updated workflow test.yml file. Additionally, a warning is printed via `core.warning` if the artifact is not found while `allow-not-found` is set to true.

If `allow-not-found` is set to false (default behavior), the action behaves as it did before this PR. 