### PR TITLE
Update workflow to not use environments 

### DIFF
--- a/.github/workflows/release-new-action-version.yml
+++ b/.github/workflows/release-new-action-version.yml
@@ -16,8 +16,6 @@ permissions:
 jobs:
   update_tag:
     name: Update the major tag to include the ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }} changes
-    environment:
-      name: releaseNewActionVersion
     runs-on: ubuntu-latest
     steps:
     - name: Update the ${{ env.TAG_NAME }} tag


### PR DESCRIPTION
To improve the publishing process, we added `SLACK_WEBHOOK` as an org-level secret, so we will depreciate using the environment.