### PR TITLE
Clarify merge-multiple documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ For assistance with breaking changes, see [MIGRATION.md](docs/MIGRATION.md).
     pattern:
 
     # When multiple artifacts are matched, this changes the behavior of the destination directories.
-    # If true, the downloaded artifacts will be in the same directory specified by path.
+    # If true, the downloaded artifacts will be in the same directory specified by path. There is no check for file name
+    # collisions. If multiple artifacts have files with the same name, only one will end up in path.
     # If false, the downloaded artifacts will be extracted into individual named directories within the specified path.
     # Optional. Default is 'false'
     merge-multiple:


### PR DESCRIPTION
Given:
Artifact A/file.txt
Artifact B/file.txt
When:
You download with merge-multiple: true
Then:
You will have file.txt only once