### PR TITLE
updating artifact package v2.1.6

### DIFF
--- a/.licenses/npm/@actions/artifact.dep.yml
+++ b/.licenses/npm/@actions/artifact.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: "@actions/artifact"
-version: 2.1.5
+version: 2.1.6
 type: npm
 summary: Actions artifact lib
 homepage: https://github.com/actions/toolkit/tree/main/packages/artifact

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "download-artifact",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "download-artifact",
-      "version": "4.1.5",
+      "version": "4.1.6",
       "license": "MIT",
       "dependencies": {
-        "@actions/artifact": "^2.1.5",
+        "@actions/artifact": "^2.1.6",
         "@actions/core": "^1.10.1",
         "@actions/github": "^5.1.1",
         "minimatch": "^9.0.3"
@@ -36,9 +36,9 @@
       }
     },
     "node_modules/@actions/artifact": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-2.1.5.tgz",
-      "integrity": "sha512-V98roImcfgWq7YtL2gzT2p2PTv1oy7k1xloq2RW/EDsJ7fX4oL7x8v9bLmmTPQ5+f4OrUbwveDZNw4iSjbtiWA==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-2.1.6.tgz",
+      "integrity": "sha512-IYdauOIXyCMsGaNlqiTkNHlPwWOmRiJTMLOlLZY/S8mnWbkxXprlks3aV2a4PHeDEHg4MVC6+2y8rtVnEG5uPA==",
       "dependencies": {
         "@actions/core": "^1.10.0",
         "@actions/github": "^5.1.1",
@@ -6172,9 +6172,9 @@
       "dev": true
     },
     "@actions/artifact": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-2.1.5.tgz",
-      "integrity": "sha512-V98roImcfgWq7YtL2gzT2p2PTv1oy7k1xloq2RW/EDsJ7fX4oL7x8v9bLmmTPQ5+f4OrUbwveDZNw4iSjbtiWA==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-2.1.6.tgz",
+      "integrity": "sha512-IYdauOIXyCMsGaNlqiTkNHlPwWOmRiJTMLOlLZY/S8mnWbkxXprlks3aV2a4PHeDEHg4MVC6+2y8rtVnEG5uPA==",
       "requires": {
         "@actions/core": "^1.10.0",
         "@actions/github": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "download-artifact",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "description": "Download an Actions Artifact from a workflow run",
   "main": "dist/index.js",
   "scripts": {
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/actions/download-artifact#readme",
   "dependencies": {
-    "@actions/artifact": "^2.1.5",
+    "@actions/artifact": "^2.1.6",
     "@actions/core": "^1.10.1",
     "@actions/github": "^5.1.1",
     "minimatch": "^9.0.3"


### PR DESCRIPTION
We want to include the [updates](https://github.com/actions/toolkit/commit/b384fe17ba3eaae4a3ba0b3c839f328f69ac2e4c) in `@actions/artifact` from v2.1.6 in `download-artifact`. 