### PR TITLE
Add Recommended Permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,3 +251,10 @@ If you must preserve permissions, you can `tar` all of your files together befor
     name: my-artifact
     path: my_files.tar
 ```
+
+# Recommended Permissions
+
+The `actions/download-artifact` workflow relies on an internal authentication pattern and does not use the GITHUB_TOKEN, to reduce risk of over-privileged token, jobs that use `actions/download-artifact` should set permissions to none:
+
+```yaml
+perm


### PR DESCRIPTION
To reduce risk of over-privileged tokens, we are adding recommended permissions to popular GitHub-owned Actions READMEs. Please confirm these permissions are correct and merge the change. Thank you!