### PR TITLE
Bump artifact version, do digest check

### DIFF
--- a/.licenses/npm/@actions/artifact.dep.yml
+++ b/.licenses/npm/@actions/artifact.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: "@actions/artifact"
-version: 2.2.2
+version: 2.3.1
 type: npm
 summary: Actions artifact lib
 homepage: https://github.com/actions/toolkit/tree/main/packages/artifact

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "download-artifact",
-  "version": "4.1.9",
+  "version": "4.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "download-artifact",
-      "version": "4.1.9",
+      "version": "4.2.0",
       "license": "MIT",
       "dependencies": {
         "@actions/artifact": "^2.2.2",
@@ -36,9 +36,9 @@
       }
     },
     "node_modules/@actions/artifact": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-2.2.2.tgz",
-      "integrity": "sha512-UtS1kcINiPRkI3/hDKkO/XdrtKo89kn8s81J67QNBU6RRMWSSXrrfCCbQVThuxcdW2boOLv51NVCEKyo954A2A==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-2.3.1.tgz",
+      "integrity": "sha512-3uW25BNAqbMBcasNK+DX4I0Vl8aQdo65K6DRufJiNYjqfhSMfeRE4YGjWLaKmF+H+7bp1ADlQ5NksC61fpvYbQ==",
       "dependencies": {
         "@actions/core": "^1.10.0",
         "@actions/github": "^5.1.1",
@@ -6032,9 +6032,9 @@
       "dev": true
     },
     "@actions/artifact": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-2.2.2.tgz",
-      "integrity": "sha512-UtS1kcINiPRkI3/hDKkO/XdrtKo89kn8s81J67QNBU6RRMWSSXrrfCCbQVThuxcdW2boOLv51NVCEKyo954A2A==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-2.3.1.tgz",
+      "integrity": "sha512-3uW25BNAqbMBcasNK+DX4I0Vl8aQdo65K6DRufJiNYjqfhSMfeRE4YGjWLaKmF+H+7bp1ADlQ5NksC61fpvYbQ==",
       "requires": {
         "@actions/core": "^1.10.0",
         "@actions/github": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "download-artifact",
-  "version": "4.1.9",
+  "version": "4.2.0",
   "description": "Download an Actions Artifact from a workflow run",
   "main": "dist/index.js",
   "scripts": {
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/actions/download-artifact#readme",
   "dependencies": {
-    "@actions/artifact": "^2.2.2",
+    "@actions/artifact": "^2.3.1",
     "@actions/core": "^1.10.1",
     "@actions/github": "^5.1.1",
     "minimatch": "^9.0.3"


### PR DESCRIPTION
This pull request includes changes to the action to provide artifact integrity verification by adding digest validation.

This also prints the computed digest to the log as info, and produces a warning if there's a mismatch. If there isn't, the only change in output will be the printed digest.