### PR TITLE
Update to use artifact 2.3.2 package

### DIFF
--- a/.licenses/npm/@actions/artifact.dep.yml
+++ b/.licenses/npm/@actions/artifact.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: "@actions/artifact"
-version: 2.2.2
+version: 2.3.2
 type: npm
 summary: Actions artifact lib
 homepage: https://github.com/actions/toolkit/tree/main/packages/artifact

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.1.9",
       "license": "MIT",
       "dependencies": {
-        "@actions/artifact": "^2.2.2",
+        "@actions/artifact": "^2.3.2",
         "@actions/core": "^1.10.1",
         "@actions/github": "^5.1.1",
         "minimatch": "^9.0.3"
@@ -36,9 +36,10 @@
       }
     },
     "node_modules/@actions/artifact": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-2.2.2.tgz",
-      "integrity": "sha512-UtS1kcINiPRkI3/hDKkO/XdrtKo89kn8s81J67QNBU6RRMWSSXrrfCCbQVThuxcdW2boOLv51NVCEKyo954A2A==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-2.3.2.tgz",
+      "integrity": "sha512-uX2Mr5KEPcwnzqa0Og9wOTEKIae6C/yx9P/m8bIglzCS5nZDkcQC/zRWjjoEsyVecL6oQpBx5BuqQj/yuVm0gw==",
+      "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",
         "@actions/github": "^5.1.1",
@@ -6032,9 +6033,9 @@
       "dev": true
     },
     "@actions/artifact": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-2.2.2.tgz",
-      "integrity": "sha512-UtS1kcINiPRkI3/hDKkO/XdrtKo89kn8s81J67QNBU6RRMWSSXrrfCCbQVThuxcdW2boOLv51NVCEKyo954A2A==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-2.3.2.tgz",
+      "integrity": "sha512-uX2Mr5KEPcwnzqa0Og9wOTEKIae6C/yx9P/m8bIglzCS5nZDkcQC/zRWjjoEsyVecL6oQpBx5BuqQj/yuVm0gw==",
       "requires": {
         "@actions/core": "^1.10.0",
         "@actions/github": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/actions/download-artifact#readme",
   "dependencies": {
-    "@actions/artifact": "^2.2.2",
+    "@actions/artifact": "^2.3.2",
     "@actions/core": "^1.10.1",
     "@actions/github": "^5.1.1",
     "minimatch": "^9.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "download-artifact",
-  "version": "4.1.9",
+  "version": "4.1.10",
   "description": "Download an Actions Artifact from a workflow run",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
This pull request includes updates to the `@actions/artifact` library version in both the `.licenses/npm/@actions/artifact.dep.yml` and `package.json` files.

Dependency updates:

* [`.licenses/npm/@actions/artifact.dep.yml`](diffhunk://#diff-318ab40e5207ff40af8a3ebe449f258e389a5d50d126b97f6ff18c607bd7e384L3-R3): Updated `@actions/artifact` version from 2.2.2 to 2.3.2.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L31-R31): Updated `@actions/artifact` version from 2.2.2 to 2.3.2.


## Updates to cache since the last package update:

### 2.3.2

- Added masking for Shared Access Signature (SAS) artifact URLs [#1982](https://github.com/actions/toolkit/pull/1982)
- Change hash to digest for consistent terminology across runner logs [#1991](https://github.com/actions/toolkit/pull/1991) 

### 2.3.1

- Fix comment typo on expectedHash. [#1986](https://github.com/actions/toolkit/pull/1986)

### 2.3.0

- Allow ArtifactClient to perform digest comparisons, if supplied. [#1975](https://github.com/actions/toolkit/pull/1975)
