### PR TITLE
Fix bug introduced in 4.2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,9 @@ jobs:
     - name: Format
       run: npm run format-check
 
+    - name: Run Unit Tests
+      run: npm test
+
     - name: Create artifacts
       run: |
         mkdir -p path/to/artifact-A

--- a/src/download-artifact.ts
+++ b/src/download-artifact.ts
@@ -138,10 +138,10 @@ export async function run(): Promise<void> {
         )
       }
     }
-    core.info(`Total of ${artifacts.length} artifact(s) downloaded`)
-    core.setOutput(Outputs.DownloadPath, resolvedPath)
-    core.info('Download artifact has finished successfully')
   }
+  core.info(`Total of ${artifacts.length} artifact(s) downloaded`)
+  core.setOutput(Outputs.DownloadPath, resolvedPath)
+  core.info('Download artifact has finished successfully')
 }
 
 run().catch(err =>


### PR DESCRIPTION
The output statements used to print download summary info & set download path output were erroneously moved to inside a loop, this change moves them back outside the loop, to ensure they are executed the correct amount of times in every case.

Closes [this issue](https://github.com/actions/download-artifact/issues/390)