### PR TITLE
Fix workflow example for downloading by artifact ID

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -10,11 +10,7 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
   pull_request:
-    paths-ignore:
-      - '**.md'
   workflow_dispatch:
 
 jobs:

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -219,21 +219,29 @@ To take advantage of this immutability for security purposes (to avoid potential
 jobs:
   upload:
     runs-on: ubuntu-latest
+
+    # Make the artifact ID available to the download job
+    outputs:
+      artifact-id: ${{ steps.upload-step.outputs.artifact-id }}
+
     steps:
       - name: Create a file
         run: echo "hello world" > my-file.txt
       - name: Upload Artifact
-        id: upload
+        id: upload-step
         uses: actions/upload-artifact@v4
         with:
           name: my-artifact
           path: my-file.txt
       # The upload step outputs the artifact ID
       - name: Print Artifact ID
-        run: echo "Artifact ID is ${{ steps.upload.outputs.artifact-id }}"
+        run: echo "Artifact ID is ${{ steps.upload-step.outputs.artifact-id }}"
+
   download:
     needs: upload
+
     runs-on: ubuntu-latest
+
     steps:
       - name: Download Artifact by ID
         uses: actions/download-artifact@v4


### PR DESCRIPTION
- #401


@ramonpetgrave64 pointed out that the upload job was not defining any outputs, preventing this example from working:
https://github.com/actions/download-artifact/pull/401#discussion_r2054512579


I've updated the example to define that job output and make it clear that the upload step output is not being passed directly between jobs. I've also added some spacing for readability.