### PR TITLE
fix: inconsistent path behavior for single artifact downloads by ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ See also [upload-artifact](https://github.com/actions/upload-artifact).
   - [v4 - What's new](#v4---whats-new)
     - [Improvements](#improvements)
     - [Breaking Changes](#breaking-changes)
+  - [Note](#note)
   - [Usage](#usage)
     - [Inputs](#inputs)
     - [Outputs](#outputs)
@@ -89,6 +90,7 @@ You are welcome to still raise bugs in this repo.
     # When multiple artifacts are matched, this changes the behavior of the destination directories.
     # If true, the downloaded artifacts will be in the same directory specified by path.
     # If false, the downloaded artifacts will be extracted into individual named directories within the specified path.
+    # Note: When downloading a single artifact (by name or ID), it will always be extracted directly to the specified path.
     # Optional. Default is 'false'
     merge-multiple:
 
@@ -145,6 +147,8 @@ steps:
 
 The `artifact-ids` input allows downloading artifacts using their unique ID rather than name. This is particularly useful when working with immutable artifacts from `actions/upload-artifact@v4` which assigns a unique ID to each artifact.
 
+Download a single artifact by ID to the current working directory (`$GITHUB_WORKSPACE`):
+
 ```yaml
 steps:
 - uses: actions/download-artifact@v4
@@ -153,6 +157,20 @@ steps:
 - name: Display structure of downloaded files
   run: ls -R
 ```
+
+Download a single artifact by ID to a specific directory:
+
+```yaml
+steps:
+- uses: actions/download-artifact@v4
+  with:
+    artifact-ids: 12345
+    path: your/destination/dir
+- name: Display structure of downloaded files
+  run: ls -R your/destination/dir
+```
+
+When downloading a single artifact by ID, the behavior is identical to downloading by name - the artifact contents are extracted directly to the specified path without creating a subdirectory.
 
 Multiple artifacts can be downloaded by providing a comma-separated list of IDs:
 
@@ -166,7 +184,7 @@ steps:
   run: ls -R path/to/artifacts
 ```
 
-This will download multiple artifacts to separate directories (similar to downloading multiple artifacts by name).
+When downloading multiple artifacts by ID, each artifact will be extracted into its own subdirectory named after the artifact (similar to downloading multiple artifacts by name).
 
 ### Download All Artifacts
 

--- a/__tests__/download.test.ts
+++ b/__tests__/download.test.ts
@@ -371,4 +371,37 @@ describe('download', () => {
       "Inputs 'name' and 'artifact-ids' cannot be used together. Please specify only one."
     )
   })
+
+  test('downloads single artifact by ID to same path as by name', async () => {
+    const mockArtifact = {
+      id: 456,
+      name: 'test-artifact',
+      size: 1024,
+      digest: 'def456'
+    }
+
+    mockInputs({
+      [Inputs.Name]: '',
+      [Inputs.Pattern]: '',
+      [Inputs.ArtifactIds]: '456',
+      [Inputs.Path]: '/test/path'
+    })
+
+    jest.spyOn(artifact, 'listArtifacts').mockImplementation(() =>
+      Promise.resolve({
+        artifacts: [mockArtifact]
+      })
+    )
+
+    await run()
+
+    // Verify it downloads directly to the specified path (not nested in artifact name subdirectory)
+    expect(artifact.downloadArtifact).toHaveBeenCalledWith(
+      456,
+      expect.objectContaining({
+        path: '/test/path', // Should be the resolved path directly, not /test/path/test-artifact
+        expectedHash: mockArtifact.digest
+      })
+    )
+  })
 })

--- a/src/download-artifact.ts
+++ b/src/download-artifact.ts
@@ -174,7 +174,9 @@ export async function run(): Promise<void> {
     promise: artifactClient.downloadArtifact(artifact.id, {
       ...options,
       path:
-        isSingleArtifactDownload || inputs.mergeMultiple
+        isSingleArtifactDownload ||
+        inputs.mergeMultiple ||
+        artifacts.length === 1
           ? resolvedPath
           : path.join(resolvedPath, artifact.name),
       expectedHash: artifact.digest


### PR DESCRIPTION
# Inconsistent path behavior for single artifact downloads by ID

When downloading a single artifact, there is an inconsistency in the path behavior depending on how the artifact was specified:

- **By name**: `artifact-ids: my-artifact` → extracts directly to specified path (e.g., `dist/`)
- **By ID**: `artifact-ids: 12345` → creates nested directory (e.g., `dist/my-artifact/`)

This inconsistency was confusing and may have forced users to work around it by setting `merge-multiple: true` even for single artifact downloads.

## Solution

Modified the path determination logic to treat single artifact downloads consistently, regardless of whether they're specified by name or artifact ID.

**Key change**: Added `artifacts.length === 1` condition to the path logic, so single artifact downloads always extract directly to the specified path.