### PR TITLE
Update GHES guidance to include reference to Node 20 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Note: This change also applies to patterns that only match a single artifact.
 ## v4 - What's new
 
 > [!IMPORTANT]
-> download-artifact@v4+ is not currently supported on GitHub Enterprise Server (GHES) yet. If you are on GHES, you must use [v3](https://github.com/actions/download-artifact/releases/tag/v3) (Node 16) or [v3-node20](https://github.com/actions/upload-artifact/releases/tag/v3-node20) (Node 20).
+> download-artifact@v4+ is not currently supported on GitHub Enterprise Server (GHES) yet. If you are on GHES, you must use [v3](https://github.com/actions/download-artifact/releases/tag/v3) (Node 16) or [v3-node20](https://github.com/actions/download-artifact/releases/tag/v3-node20) (Node 20).
 
 The release of upload-artifact@v4 and download-artifact@v4 are major changes to the backend architecture of Artifacts. They have numerous performance and behavioral improvements.
 


### PR DESCRIPTION
Similarly to [the change](https://github.com/actions/upload-artifact/pull/725) in `upload-artifact`:

`v3` ([link](https://github.com/actions/download-artifact/releases/tag/v3)) uses Node 16 which is deprecated. `v3-node20` ([link](https://github.com/actions/download-artifact/releases/tag/v3-node20)) has been available for a while which uses Node 20 so we should reflect this in the documentation.