### PR TITLE
Add regression tests for CJK characters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -187,3 +187,142 @@ jobs:
           ls -al ext-test/raw/
           exit 1
         fi
+
+    # Test uploading and downloading artifacts with CJK (Chinese, Japanese, Korean) characters
+    # Regression test: certain non-ASCII chars (e.g. U+571F 土) caused 400 errors from
+    # Azure Blob Storage due to encoding issues in the Content-Disposition / rscd parameter
+    - name: Create artifacts with CJK names
+      shell: bash
+      run: |
+        mkdir -p path/to/cjk-artifacts
+        # Chinese - 土 (U+571F) known to fail, 日 (U+65E5) known to work
+        echo "Content for 土" > path/to/cjk-artifacts/file-土.txt
+        echo "Content for 中文测试" > path/to/cjk-artifacts/file-中文测试.txt
+        # Japanese - katakana and kanji
+        echo "Content for テスト" > path/to/cjk-artifacts/file-テスト.txt
+        echo "Content for 東京タワー" > path/to/cjk-artifacts/file-東京タワー.txt
+        # Korean - Hangul
+        echo "Content for 테스트" > path/to/cjk-artifacts/file-테스트.txt
+        echo "Content for 서울시" > path/to/cjk-artifacts/file-서울시.txt
+
+    - name: Upload CJK artifact - Chinese 土
+      uses: actions/upload-artifact@v7
+      with:
+        name: CJK-土-${{ matrix.runs-on }}
+        path: path/to/cjk-artifacts/file-土.txt
+        archive: false
+
+    - name: Upload CJK artifact - Chinese 中文测试
+      uses: actions/upload-artifact@v7
+      with:
+        name: CJK-中文测试-${{ matrix.runs-on }}
+        path: path/to/cjk-artifacts/file-中文测试.txt
+        archive: false
+
+    - name: Upload CJK artifact - Japanese テスト
+      uses: actions/upload-artifact@v7
+      with:
+        name: CJK-テスト-${{ matrix.runs-on }}
+        path: path/to/cjk-artifacts/file-テスト.txt
+        archive: false
+
+    - name: Upload CJK artifact - Japanese 東京タワー
+      uses: actions/upload-artifact@v7
+      with:
+        name: CJK-東京タワー-${{ matrix.runs-on }}
+        path: path/to/cjk-artifacts/file-東京タワー.txt
+        archive: false
+
+    - name: Upload CJK artifact - Korean 테스트
+      uses: actions/upload-artifact@v7
+      with:
+        name: CJK-테스트-${{ matrix.runs-on }}
+        path: path/to/cjk-artifacts/file-테스트.txt
+        archive: false
+
+    - name: Upload CJK artifact - Korean 서울시
+      uses: actions/upload-artifact@v7
+      with:
+        name: CJK-서울시-${{ matrix.runs-on }}
+        path: path/to/cjk-artifacts/file-서울시.txt
+        archive: false
+
+    - name: Download CJK artifact - Chinese 土
+      uses: ./
+      with:
+        name: CJK-土-${{ matrix.runs-on }}
+        path: cjk-download/土
+
+    - name: Download CJK artifact - Chinese 中文测试
+      uses: ./
+      with:
+        name: CJK-中文测试-${{ matrix.runs-on }}
+        path: cjk-download/中文测试
+
+    - name: Download CJK artifact - Japanese テスト
+      uses: ./
+      with:
+        name: CJK-テスト-${{ matrix.runs-on }}
+        path: cjk-download/テスト
+
+    - name: Download CJK artifact - Japanese 東京タワー
+      uses: ./
+      with:
+        name: CJK-東京タワー-${{ matrix.runs-on }}
+        path: cjk-download/東京タワー
+
+    - name: Download CJK artifact - Korean 테스트
+      uses: ./
+      with:
+        name: CJK-테스트-${{ matrix.runs-on }}
+        path: cjk-download/테스트
+
+    - name: Download CJK artifact - Korean 서울시
+      uses: ./
+      with:
+        name: CJK-서울시-${{ matrix.runs-on }}
+        path: cjk-download/서울시
+
+    - name: Verify CJK artifact downloads
+      shell: bash
+      run: |
+        set -e
+        fail=0
+
+        check_file() {
+          local file="$1"
+          local expected="$2"
+          if [ ! -f "$file" ]; then
+            echo "FAIL: Missing file: $file"
+            fail=1
+            return
+          fi
+          actual=$(cat "$file")
+          if [ "$actual" != "$expected" ]; then
+            echo "FAIL: Content mismatch in $file"
+            echo "  Expected: '$expected'"
+            echo "  Got:      '$actual'"
+            fail=1
+            return
+          fi
+          echo "PASS: $file"
+        }
+
+        echo "=== Chinese ==="
+        check_file "cjk-download/土/file-土.txt" "Content for 土"
+        check_file "cjk-download/中文测试/file-中文测试.txt" "Content for 中文测试"
+
+        echo "=== Japanese ==="
+        check_file "cjk-download/テスト/file-テスト.txt" "Content for テスト"
+        check_file "cjk-download/東京タワー/file-東京タワー.txt" "Content for 東京タワー"
+
+        echo "=== Korean ==="
+        check_file "cjk-download/테스트/file-테스트.txt" "Content for 테스트"
+        check_file "cjk-download/서울시/file-서울시.txt" "Content for 서울시"
+
+        if [ "$fail" -ne 0 ]; then
+          echo "Some CJK artifact checks failed"
+          ls -alR cjk-download/ || true
+          exit 1
+        fi
+        echo "All CJK artifact downloads verified successfully"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,91 +196,85 @@ jobs:
       run: |
         mkdir -p path/to/cjk-artifacts
         # Chinese - 土 (U+571F) known to fail, 日 (U+65E5) known to work
-        echo "Content for 土" > path/to/cjk-artifacts/file-土.txt
-        echo "Content for 中文测试" > path/to/cjk-artifacts/file-中文测试.txt
+        echo "Content for 土" > "path/to/cjk-artifacts/file-土-${{ matrix.runs-on }}.txt"
+        echo "Content for 中文测试" > "path/to/cjk-artifacts/file-中文测试-${{ matrix.runs-on }}.txt"
         # Japanese - katakana and kanji
-        echo "Content for テスト" > path/to/cjk-artifacts/file-テスト.txt
-        echo "Content for 東京タワー" > path/to/cjk-artifacts/file-東京タワー.txt
+        echo "Content for テスト" > "path/to/cjk-artifacts/file-テスト-${{ matrix.runs-on }}.txt"
+        echo "Content for 東京タワー" > "path/to/cjk-artifacts/file-東京タワー-${{ matrix.runs-on }}.txt"
         # Korean - Hangul
-        echo "Content for 테스트" > path/to/cjk-artifacts/file-테스트.txt
-        echo "Content for 서울시" > path/to/cjk-artifacts/file-서울시.txt
+        echo "Content for 테스트" > "path/to/cjk-artifacts/file-테스트-${{ matrix.runs-on }}.txt"
+        echo "Content for 서울시" > "path/to/cjk-artifacts/file-서울시-${{ matrix.runs-on }}.txt"
 
     - name: Upload CJK artifact - Chinese 土
       uses: actions/upload-artifact@v7
       with:
-        name: CJK-土-${{ matrix.runs-on }}
-        path: path/to/cjk-artifacts/file-土.txt
+        path: path/to/cjk-artifacts/file-土-${{ matrix.runs-on }}.txt
         archive: false
 
     - name: Upload CJK artifact - Chinese 中文测试
       uses: actions/upload-artifact@v7
       with:
-        name: CJK-中文测试-${{ matrix.runs-on }}
-        path: path/to/cjk-artifacts/file-中文测试.txt
+        path: path/to/cjk-artifacts/file-中文测试-${{ matrix.runs-on }}.txt
         archive: false
 
     - name: Upload CJK artifact - Japanese テスト
       uses: actions/upload-artifact@v7
       with:
-        name: CJK-テスト-${{ matrix.runs-on }}
-        path: path/to/cjk-artifacts/file-テスト.txt
+        path: path/to/cjk-artifacts/file-テスト-${{ matrix.runs-on }}.txt
         archive: false
 
     - name: Upload CJK artifact - Japanese 東京タワー
       uses: actions/upload-artifact@v7
       with:
-        name: CJK-東京タワー-${{ matrix.runs-on }}
-        path: path/to/cjk-artifacts/file-東京タワー.txt
+        path: path/to/cjk-artifacts/file-東京タワー-${{ matrix.runs-on }}.txt
         archive: false
 
     - name: Upload CJK artifact - Korean 테스트
       uses: actions/upload-artifact@v7
       with:
-        name: CJK-테스트-${{ matrix.runs-on }}
-        path: path/to/cjk-artifacts/file-테스트.txt
+        path: path/to/cjk-artifacts/file-테스트-${{ matrix.runs-on }}.txt
         archive: false
 
     - name: Upload CJK artifact - Korean 서울시
       uses: actions/upload-artifact@v7
       with:
-        name: CJK-서울시-${{ matrix.runs-on }}
-        path: path/to/cjk-artifacts/file-서울시.txt
+        path: path/to/cjk-artifacts/file-서울시-${{ matrix.runs-on }}.txt
         archive: false
 
     - name: Download CJK artifact - Chinese 土
       uses: ./
       with:
-        name: CJK-土-${{ matrix.runs-on }}
+        name: file-土-${{ matrix.runs-on }}.txt
         path: cjk-download/土
 
     - name: Download CJK artifact - Chinese 中文测试
       uses: ./
       with:
-        name: CJK-中文测试-${{ matrix.runs-on }}
+        name: file-中文测试-${{ matrix.runs-on }}.txt
         path: cjk-download/中文测试
 
     - name: Download CJK artifact - Japanese テスト
       uses: ./
       with:
-        name: CJK-テスト-${{ matrix.runs-on }}
+        name: file-テスト-${{ matrix.runs-on }}.txt
         path: cjk-download/テスト
 
     - name: Download CJK artifact - Japanese 東京タワー
       uses: ./
       with:
-        name: CJK-東京タワー-${{ matrix.runs-on }}
+        name: file-東京タワー-${{ matrix.runs-on }}.txt
         path: cjk-download/東京タワー
 
     - name: Download CJK artifact - Korean 테스트
       uses: ./
       with:
-        name: CJK-테스트-${{ matrix.runs-on }}
+        name: file-테스트-${{ matrix.runs-on }}.txt
         path: cjk-download/테스트
 
     - name: Download CJK artifact - Korean 서울시
       uses: ./
       with:
-        name: CJK-서울시-${{ matrix.runs-on }}
+        name: file-서울시-${{ matrix.runs-on }}.txt
         path: cjk-download/서울시
 
     - name: Verify CJK artifact downloads
@@ -309,16 +303,16 @@ jobs:
         }
 
         echo "=== Chinese ==="
-        check_file "cjk-download/土/file-土.txt" "Content for 土"
-        check_file "cjk-download/中文测试/file-中文测试.txt" "Content for 中文测试"
+        check_file "cjk-download/土/file-土-${{ matrix.runs-on }}.txt" "Content for 土"
+        check_file "cjk-download/中文测试/file-中文测试-${{ matrix.runs-on }}.txt" "Content for 中文测试"
 
         echo "=== Japanese ==="
-        check_file "cjk-download/テスト/file-テスト.txt" "Content for テスト"
-        check_file "cjk-download/東京タワー/file-東京タワー.txt" "Content for 東京タワー"
+        check_file "cjk-download/テスト/file-テスト-${{ matrix.runs-on }}.txt" "Content for テスト"
+        check_file "cjk-download/東京タワー/file-東京タワー-${{ matrix.runs-on }}.txt" "Content for 東京タワー"
 
         echo "=== Korean ==="
-        check_file "cjk-download/테스트/file-테스트.txt" "Content for 테스트"
-        check_file "cjk-download/서울시/file-서울시.txt" "Content for 서울시"
+        check_file "cjk-download/테스트/file-테스트-${{ matrix.runs-on }}.txt" "Content for 테스트"
+        check_file "cjk-download/서울시/file-서울시-${{ matrix.runs-on }}.txt" "Content for 서울시"
 
         if [ "$fail" -ne 0 ]; then
           echo "Some CJK artifact checks failed"

--- a/.licenses/npm/@actions/artifact.dep.yml
+++ b/.licenses/npm/@actions/artifact.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: "@actions/artifact"
-version: 6.1.0
+version: 6.2.1
 type: npm
 summary: Actions artifact lib
 homepage: https://github.com/actions/toolkit/tree/main/packages/artifact

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ See also [upload-artifact](https://github.com/actions/upload-artifact).
 
 - Chore: we've bumped versions on a lot of our dev packages to get them up to date with the latest bugfixes/security patches.
 
+### v8.0.1
+
+- Support for CJK (Chinese/Japanese/Korean) characters in the file name.
+
 ## v7 - What's new
 
 > [!IMPORTANT]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "download-artifact",
-  "version": "7.0.0",
+  "version": "8.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "download-artifact",
-      "version": "7.0.0",
+      "version": "8.0.1",
       "license": "MIT",
       "dependencies": {
-        "@actions/artifact": "^6.1.0",
+        "@actions/artifact": "^6.2.1",
         "@actions/core": "^3.0.0",
         "minimatch": "^10.1.1"
       },
@@ -36,9 +36,9 @@
       }
     },
     "node_modules/@actions/artifact": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-6.1.0.tgz",
-      "integrity": "sha512-oRn9YhKkboXgIq2TQZ9uj6bhkT5ZUzFtnyTQ0tLGBwImaD0GfWShE5R0tPbN25EJmS3tz5sDd2JnVokAOtNrZQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@actions/artifact/-/artifact-6.2.1.tgz",
+      "integrity": "sha512-sJGH0mhEbEjBCw7o6SaLhUU66u27aFW8HTfkIb5Tk2/Wy0caUDc+oYQEgnuFN7a0HCpAbQyK0U6U7XUJDgDWrw==",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "download-artifact",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Download an Actions Artifact from a workflow run",
   "type": "module",
   "engines": {
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/actions/download-artifact#readme",
   "dependencies": {
-    "@actions/artifact": "^6.1.0",
+    "@actions/artifact": "^6.2.1",
     "@actions/core": "^3.0.0",
     "minimatch": "^10.1.1"
   },


### PR DESCRIPTION
## Description

CJK (Chinese/Japanese/Korean) characters can cause failures during download. The latest version of `@actions/artifact` supports handling them so this PR bumps that dependency and adds a regression test.