### PR TITLE
Add a regression test for artifact name + content-type mismatches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,20 +166,20 @@ jobs:
         echo '{"key": "value"}' > path/to/extension-test/data.json
     - uses: actions/upload-artifact@v4 # V4 is important here to ensure we're supporting older versions correctly
       with:
-        name: report.txt-${{ matrix.runs-on }}
+        name: report.txt-${{ matrix.runs-on }}.json
         path: path/to/extension-test/data.json
 
     - name: Download misleading-extension artifact without decompressing
       uses: ./
       with:
-        name: report.txt-${{ matrix.runs-on }}
+        name: report.txt-${{ matrix.runs-on }}.json
         path: ext-test/raw
         skip-decompress: true
 
     - name: Verify downloaded file has .zip extension appended
       shell: bash
       run: |
-        expected="ext-test/raw/report.txt-${{ matrix.runs-on }}.zip"
+        expected="ext-test/raw/report.txt-${{ matrix.runs-on }}.json.zip"
         if [ -f "$expected" ]; then
           echo "PASS: Downloaded file has .zip appended: $expected"
         else


### PR DESCRIPTION
## Description

We have reports of older archive files being uploaded (with the v4 action) and the downloaded `Content-Disposition` returns a file without the `.zip` extension. This only happens when the artifact name has a file type extension (ie. `report.txt`). This adds tests for that scenario so we can know when we're green again.