### PR TITLE
Add 'artifacts-downloaded' to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ You are welcome to still raise bugs in this repo.
 
 | Name | Description | Example |
 | - | - | - |
+| `artifacts-downloaded` | The number of artifacts downloaded | `1` |
 | `download-path` | Absolute path where the artifact(s) were downloaded | `/tmp/my/download/path` |
 
 ## Examples

--- a/__tests__/download.test.ts
+++ b/__tests__/download.test.ts
@@ -112,6 +112,8 @@ describe('download', () => {
     )
     expect(core.info).toHaveBeenCalledWith('Total of 1 artifact(s) downloaded')
 
+    expect(core.setOutput).toHaveBeenCalledWith('artifacts-downloaded', 1)
+
     expect(core.setOutput).toHaveBeenCalledWith(
       'download-path',
       expect.any(String)
@@ -151,6 +153,7 @@ describe('download', () => {
     )
 
     expect(core.info).toHaveBeenCalledWith('Total of 2 artifact(s) downloaded')
+    expect(core.setOutput).toHaveBeenCalledWith('artifacts-downloaded', 2)
     expect(artifact.default.downloadArtifact).toHaveBeenCalledTimes(2)
   })
 
@@ -169,6 +172,8 @@ describe('download', () => {
     )
 
     expect(core.info).toHaveBeenCalledWith('Total of 0 artifact(s) downloaded')
+
+    expect(core.setOutput).toHaveBeenCalledWith('artifacts-downloaded', 0)
   })
 
   test('filters artifacts by pattern', async () => {
@@ -193,6 +198,7 @@ describe('download', () => {
       123,
       expect.anything()
     )
+    expect(core.setOutput).toHaveBeenCalledWith('artifacts-downloaded', 1)
   })
 
   test('uses token and repository information when provided', async () => {
@@ -335,6 +341,7 @@ describe('download', () => {
       expect.stringContaining('digest validation failed')
     )
     expect(core.info).toHaveBeenCalledWith('Total of 1 artifact(s) downloaded')
+    expect(core.setOutput).toHaveBeenCalledWith('artifacts-downloaded', 1)
   })
 
   test('downloads a single artifact by ID', async () => {
@@ -369,6 +376,7 @@ describe('download', () => {
       })
     )
     expect(core.info).toHaveBeenCalledWith('Total of 1 artifact(s) downloaded')
+    expect(core.setOutput).toHaveBeenCalledWith('artifacts-downloaded', 1)
   })
 
   test('downloads multiple artifacts by ID', async () => {
@@ -406,6 +414,7 @@ describe('download', () => {
       )
     })
     expect(core.info).toHaveBeenCalledWith('Total of 3 artifact(s) downloaded')
+    expect(core.setOutput).toHaveBeenCalledWith('artifacts-downloaded', 3)
   })
 
   test('warns when some artifact IDs are not found', async () => {
@@ -432,6 +441,7 @@ describe('download', () => {
     )
     expect(core.debug).toHaveBeenCalledWith('Found 1 artifacts by ID')
     expect(artifact.default.downloadArtifact).toHaveBeenCalledTimes(1)
+    expect(core.setOutput).toHaveBeenCalledWith('artifacts-downloaded', 1)
   })
 
   test('throws error when no artifacts with requested IDs are found', async () => {

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,8 @@ inputs:
     required: false
     default: 'error'
 outputs:
+  artifacts-downloaded:
+    description: 'The number of artifacts downloaded'
   download-path:
     description: 'Path of artifact download'
 runs:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,5 +19,6 @@ export enum DigestMismatchBehavior {
 }
 
 export enum Outputs {
+  ArtifactsDownloaded = 'artifacts-downloaded',
   DownloadPath = 'download-path'
 }

--- a/src/download-artifact.ts
+++ b/src/download-artifact.ts
@@ -242,6 +242,7 @@ export async function run(): Promise<void> {
   }
 
   core.info(`Total of ${artifacts.length} artifact(s) downloaded`)
+  core.setOutput(Outputs.ArtifactsDownloaded, artifacts.length)
   core.setOutput(Outputs.DownloadPath, resolvedPath)
   core.info('Download artifact has finished successfully')
 }


### PR DESCRIPTION
This adds `artifacts-downloaded` to the action outputs and returns the number of artifacts that were downloaded.