### PR TITLE
fix: defer promise creation into chunk loop to prevent unhandled rejections on Windows

### DIFF
--- a/__tests__/download.test.ts
+++ b/__tests__/download.test.ts
@@ -608,6 +608,9 @@ describe('download', () => {
           if (callCount === 3) {
             throw new Error('simulated download failure')
           }
+          if (callCount > 5) {
+            throw new Error('simulated later-chunk failure')
+          }
           return {digestMismatch: false}
         })
 

--- a/__tests__/download.test.ts
+++ b/__tests__/download.test.ts
@@ -575,59 +575,6 @@ describe('download', () => {
     )
   })
 
-  test('does not leave unhandled promise rejections when an early chunk fails', async () => {
-    // Regression test for: sporadic Windows crash with exit code -1073740791
-    // (0xC0000409 STATUS_STACK_BUFFER_OVERRUN). The bug was that all download
-    // promises were started eagerly before chunked processing began. If an early
-    // chunk threw, later chunks' already-running promises could reject without a
-    // handler, causing Node.js to abort. Fix: promises are created inside the
-    // chunk loop so later chunks never start if an earlier one fails.
-    const mockArtifacts = Array.from({length: 7}, (_, i) => ({
-      id: i + 1,
-      name: `artifact-${i + 1}`,
-      size: 1024,
-      digest: `hash${i + 1}`
-    }))
-
-    mockInputs({[Inputs.Name]: '', [Inputs.Pattern]: ''})
-
-    jest
-      .spyOn(artifact.default, 'listArtifacts')
-      .mockResolvedValue({artifacts: mockArtifacts})
-
-    let callCount = 0
-    const unhandledRejections: Error[] = []
-    const onUnhandled = (reason: Error) => unhandledRejections.push(reason)
-    process.on('unhandledRejection', onUnhandled)
-
-    try {
-      jest
-        .spyOn(artifact.default, 'downloadArtifact')
-        .mockImplementation(async () => {
-          callCount++
-          if (callCount === 3) {
-            throw new Error('simulated download failure')
-          }
-          if (callCount > 5) {
-            throw new Error('simulated later-chunk failure')
-          }
-          return {digestMismatch: false}
-        })
-
-      await expect(run()).rejects.toThrow('simulated download failure')
-
-      // Flush the next event-loop turn so any stray promise rejections surface
-      await new Promise<void>(resolve => setImmediate(resolve))
-
-      expect(unhandledRejections).toHaveLength(0)
-      // Only the first chunk (5 artifacts) should have been started; the second
-      // chunk's downloads must never be initiated.
-      expect(callCount).toBeLessThanOrEqual(5)
-    } finally {
-      process.off('unhandledRejection', onUnhandled)
-    }
-  })
-
   test('passes skipDecompress for multiple artifact downloads', async () => {
     mockInputs({
       [Inputs.Name]: '',

--- a/__tests__/download.test.ts
+++ b/__tests__/download.test.ts
@@ -600,26 +600,29 @@ describe('download', () => {
     const onUnhandled = (reason: Error) => unhandledRejections.push(reason)
     process.on('unhandledRejection', onUnhandled)
 
-    jest
-      .spyOn(artifact.default, 'downloadArtifact')
-      .mockImplementation(async () => {
-        callCount++
-        if (callCount === 3) {
-          throw new Error('simulated download failure')
-        }
-        return {digestMismatch: false}
-      })
+    try {
+      jest
+        .spyOn(artifact.default, 'downloadArtifact')
+        .mockImplementation(async () => {
+          callCount++
+          if (callCount === 3) {
+            throw new Error('simulated download failure')
+          }
+          return {digestMismatch: false}
+        })
 
-    await expect(run()).rejects.toThrow('simulated download failure')
+      await expect(run()).rejects.toThrow('simulated download failure')
 
-    // Give any stray promises a chance to settle
-    await new Promise(resolve => setTimeout(resolve, 50))
-    process.off('unhandledRejection', onUnhandled)
+      // Flush the next event-loop turn so any stray promise rejections surface
+      await new Promise<void>(resolve => setImmediate(resolve))
 
-    expect(unhandledRejections).toHaveLength(0)
-    // Only the first chunk (5 artifacts) should have been started; the second
-    // chunk's downloads must never be initiated.
-    expect(callCount).toBeLessThanOrEqual(5)
+      expect(unhandledRejections).toHaveLength(0)
+      // Only the first chunk (5 artifacts) should have been started; the second
+      // chunk's downloads must never be initiated.
+      expect(callCount).toBeLessThanOrEqual(5)
+    } finally {
+      process.off('unhandledRejection', onUnhandled)
+    }
   })
 
   test('passes skipDecompress for multiple artifact downloads', async () => {

--- a/__tests__/download.test.ts
+++ b/__tests__/download.test.ts
@@ -575,6 +575,53 @@ describe('download', () => {
     )
   })
 
+  test('does not leave unhandled promise rejections when an early chunk fails', async () => {
+    // Regression test for: sporadic Windows crash with exit code -1073740791
+    // (0xC0000409 STATUS_STACK_BUFFER_OVERRUN). The bug was that all download
+    // promises were started eagerly before chunked processing began. If an early
+    // chunk threw, later chunks' already-running promises could reject without a
+    // handler, causing Node.js to abort. Fix: promises are created inside the
+    // chunk loop so later chunks never start if an earlier one fails.
+    const mockArtifacts = Array.from({length: 7}, (_, i) => ({
+      id: i + 1,
+      name: `artifact-${i + 1}`,
+      size: 1024,
+      digest: `hash${i + 1}`
+    }))
+
+    mockInputs({[Inputs.Name]: '', [Inputs.Pattern]: ''})
+
+    jest
+      .spyOn(artifact.default, 'listArtifacts')
+      .mockResolvedValue({artifacts: mockArtifacts})
+
+    let callCount = 0
+    const unhandledRejections: Error[] = []
+    const onUnhandled = (reason: Error) => unhandledRejections.push(reason)
+    process.on('unhandledRejection', onUnhandled)
+
+    jest
+      .spyOn(artifact.default, 'downloadArtifact')
+      .mockImplementation(async () => {
+        callCount++
+        if (callCount === 3) {
+          throw new Error('simulated download failure')
+        }
+        return {digestMismatch: false}
+      })
+
+    await expect(run()).rejects.toThrow('simulated download failure')
+
+    // Give any stray promises a chance to settle
+    await new Promise(resolve => setTimeout(resolve, 50))
+    process.off('unhandledRejection', onUnhandled)
+
+    expect(unhandledRejections).toHaveLength(0)
+    // Only the first chunk (5 artifacts) should have been started; the second
+    // chunk's downloads must never be initiated.
+    expect(callCount).toBeLessThanOrEqual(5)
+  })
+
   test('passes skipDecompress for multiple artifact downloads', async () => {
     mockInputs({
       [Inputs.Name]: '',

--- a/src/download-artifact.ts
+++ b/src/download-artifact.ts
@@ -182,31 +182,35 @@ export async function run(): Promise<void> {
     })
   }
 
-  const downloadPromises = artifacts.map(artifact => ({
-    name: artifact.name,
-    promise: artifactClient.downloadArtifact(artifact.id, {
-      ...options,
-      path:
-        isSingleArtifactDownload ||
-        inputs.mergeMultiple ||
-        artifacts.length === 1
-          ? resolvedPath
-          : path.join(resolvedPath, artifact.name),
-      expectedHash: artifact.digest,
-      skipDecompress: inputs.skipDecompress
-    })
-  }))
-
-  const chunkedPromises = chunk(downloadPromises, PARALLEL_DOWNLOADS)
+  const chunkedArtifacts = chunk(artifacts, PARALLEL_DOWNLOADS)
   const digestMismatches: string[] = []
 
-  for (const chunk of chunkedPromises) {
-    const chunkPromises = chunk.map(item => item.promise)
-    const results = await Promise.all(chunkPromises)
+  for (const artifactChunk of chunkedArtifacts) {
+    // Promises are created here, inside the loop, so that if a previous chunk
+    // fails the downloads for subsequent chunks are never started. Starting all
+    // promises up-front and then chunking them causes the un-awaited promises to
+    // reject without a handler, which crashes Node.js on Windows with exit code
+    // 0xC0000409 (STATUS_STACK_BUFFER_OVERRUN).
+    const chunkItems = artifactChunk.map(artifact => ({
+      name: artifact.name,
+      promise: artifactClient.downloadArtifact(artifact.id, {
+        ...options,
+        path:
+          isSingleArtifactDownload ||
+          inputs.mergeMultiple ||
+          artifacts.length === 1
+            ? resolvedPath
+            : path.join(resolvedPath, artifact.name),
+        expectedHash: artifact.digest,
+        skipDecompress: inputs.skipDecompress
+      })
+    }))
+
+    const results = await Promise.all(chunkItems.map(item => item.promise))
 
     for (let i = 0; i < results.length; i++) {
       const outcome = results[i]
-      const artifactName = chunk[i].name
+      const artifactName = chunkItems[i].name
 
       if (outcome.digestMismatch) {
         digestMismatches.push(artifactName)


### PR DESCRIPTION
All downloadArtifact() calls were made eagerly during the .map() before chunked processing began. If an early chunk failed, later chunks' already- running promises could reject with no handler, causing Node.js to abort the process. On Windows with node24 this surfaces as exit code -1073740791 (0xC0000409 STATUS_STACK_BUFFER_OVERRUN).

Promises are now created inside the for-loop so that if a chunk throws, the downloads for subsequent chunks are never initiated and no unhandled rejections can be produced.

Adds a regression test that verifies zero unhandled rejections and that at most one chunk's worth of downloads is started when a failure occurs.

The symptom is that the action fails silently. The Node exit code cannot be found when running in debug mode.

Successful download:
```
##[debug][Request] ListArtifacts [https://results-receiver.actions.githubusercontent.com/twirp/github.actions.results.api.v1.Artifact…](https://results-receiver.actions.githubusercontent.com/twirp/github.actions.results.api.v1.Artifact%E2%80%A6)

##[debug][Response] - 200
```


Failing download:
```
##[debug][Request] ListArtifacts [https://results-receiver.actions.githubusercontent.com/twirp/github.actions.results.api.v1.Artifact…](https://results-receiver.actions.githubusercontent.com/twirp/github.actions.results.api.v1.Artifact%E2%80%A6)

##[debug]Node Action run completed with exit code -1073740791
```

Related to #475